### PR TITLE
로그인 및 주문 기능 리팩토링 및 모듈화

### DIFF
--- a/core/jwt.py
+++ b/core/jwt.py
@@ -1,0 +1,56 @@
+import os
+from datetime import datetime, timedelta
+import jwt
+from dotenv import load_dotenv
+
+# .env 파일 로드
+load_dotenv()
+
+# JWT 설정 로드
+SECRET_KEY = os.getenv("SECRET_KEY")
+ALGORITHM = os.getenv("ALGORITHM")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 30))
+
+
+def create_access_token(user_id: int, expires_delta: timedelta = None) -> str:
+    """
+    JWT 토큰 생성 함수.
+
+    Args:
+        user_id (int): 유저 ID (Primary Key).
+        expires_delta (timedelta, optional): 토큰 만료 기간. 기본값은 ACCESS_TOKEN_EXPIRE_MINUTES.
+
+    Returns:
+        str: 생성된 JWT.
+    """
+    to_encode = {"sub": str(user_id)}
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+def extract_user_id(token: str) -> int:
+    """
+    JWT에서 유저 ID를 추출하는 함수.
+
+    Args:
+        token (str): JWT 토큰.
+
+    Returns:
+        int: 추출된 유저 ID.
+
+    Raises:
+        jwt.PyJWTError: 토큰 디코딩 실패 또는 만료된 토큰.
+        ValueError: 토큰에서 ID가 발견되지 않을 경우.
+    """
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id = payload.get("sub")
+        if user_id is None:
+            raise ValueError("Token does not contain user ID")
+        return int(user_id)
+    except jwt.ExpiredSignatureError:
+        raise ValueError("Token has expired")
+    except jwt.PyJWTError as e:
+        raise ValueError(f"Token decoding error: {str(e)}")

--- a/core/redis.py
+++ b/core/redis.py
@@ -1,0 +1,33 @@
+from core.settings import REDIS_CLIENT
+from core.websockets import manager
+import asyncio
+import json
+
+# Redis Pub/Sub Listener
+async def redis_listener():
+    # Redis 채널 구독
+    pubsub = REDIS_CLIENT.pubsub()
+    pubsub.subscribe("order_book_updates")
+    print("Redis listener started, subscribed to 'order_book_updates'")
+    try:
+        while True:
+            # Redis에서 메시지 수신
+            message = pubsub.get_message()
+            if message and message["type"] == "message":
+                data = json.loads(message["data"])
+                property_id = data.get("property_id")
+                if property_id:
+                    # WebSocket으로 브로드캐스트
+                    await manager.broadcast(json.dumps(data), property_id)
+            await asyncio.sleep(0.01)  # Redis 메시지 폴링 간격
+    except Exception as e:
+        print(f"Redis listener error: {e}")
+
+# Redis 데이터 업데이트 및 Pub/Sub 메시지 발행
+def update_order_book_in_redis(property_id: int, order_book: dict):
+    redis_key = f"order_book:{property_id}"
+    REDIS_CLIENT.hset(redis_key, "order_book", json.dumps(order_book))
+    update_message = {"property_id": property_id, "order_book": order_book}
+    REDIS_CLIENT.publish("order_book_updates", json.dumps(update_message))
+
+

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,0 +1,27 @@
+import os
+from dotenv import load_dotenv
+import redis
+
+# .env 파일 로드
+load_dotenv()
+
+# MySQL 설정
+DB_CONFIG = {
+    "host": os.getenv("DB_HOST"),
+    "user": os.getenv("DB_USER"),
+    "password": os.getenv("DB_PASSWORD"),
+    "database": os.getenv("DB_NAME"),
+    "charset": os.getenv("DB_CHARSET"),
+}
+
+# Redis 설정
+REDIS_CLIENT = redis.Redis(
+    host=os.getenv("REDIS_HOST"),
+    port=int(os.getenv("REDIS_PORT")),
+    db=int(os.getenv("REDIS_DB")),
+    decode_responses=True,
+)
+
+# 기타 설정 (예: JWT)
+JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "defaultsecretkey")
+JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")

--- a/core/websockets.py
+++ b/core/websockets.py
@@ -1,0 +1,37 @@
+from fastapi import WebSocket, WebSocketDisconnect
+from typing import Dict, List
+
+
+class ConnectionManager:
+    def __init__(self):
+        self.active_connections: Dict[int, List[WebSocket]] = {}
+
+    async def connect(self, websocket: WebSocket, property_id: int):
+        """WebSocket 연결을 수립."""
+        await websocket.accept()
+        if property_id not in self.active_connections:
+            self.active_connections[property_id] = []
+        self.active_connections[property_id].append(websocket)
+        print(f"WebSocket 연결 성공: property_id={property_id}")
+
+    def disconnect(self, websocket: WebSocket, property_id: int):
+        """WebSocket 연결을 종료."""
+        if property_id in self.active_connections:
+            self.active_connections[property_id].remove(websocket)
+            if not self.active_connections[property_id]:
+                del self.active_connections[property_id]
+            print(f"WebSocket 연결 종료: property_id={property_id}")
+
+    async def broadcast(self, message: str, property_id: int):
+        """WebSocket 메시지를 연결된 클라이언트에 브로드캐스트."""
+        if property_id in self.active_connections:
+            print(f"Broadcasting message to {len(self.active_connections[property_id])} clients for property_id {property_id}")
+            for connection in self.active_connections[property_id]:
+                try:
+                    await connection.send_text(message)
+                except Exception as e:
+                    print(f"Error sending message to WebSocket client: {e}")
+
+
+# WebSocket 연결 관리 인스턴스 생성
+manager = ConnectionManager()

--- a/domain/order/main.py
+++ b/domain/order/main.py
@@ -1,130 +1,16 @@
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
+from fastapi import FastAPI, APIRouter, WebSocket, WebSocketDisconnect, HTTPException
 from contextlib import asynccontextmanager
+from core.settings import DB_CONFIG, REDIS_CLIENT
+from core.websockets import manager
 import pymysql
-import redis
 import asyncio
 import json
-import os
 from pydantic import BaseModel
-from dotenv import load_dotenv
 
-# .env 파일 로드
-load_dotenv()
+# 라우터 생성
+router = APIRouter()
 
-# MySQL 설정
-db_config = {
-    "host": os.getenv("DB_HOST"),
-    "user": os.getenv("DB_USER"),
-    "password": os.getenv("DB_PASSWORD"),
-    "database":os.getenv("DB_NAME"),
-    "charset": os.getenv("DB_CHARSET"),
-}
-
-# Redis 설정
-redis_client = redis.Redis(
-    host=os.getenv("REDIS_HOST"),
-    port=int(os.getenv("REDIS_PORT")),
-    db=int(os.getenv("REDIS_DB")),
-    decode_responses=True
-)
-
-# FastAPI 앱 생성
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    print("Application startup")
-    loop = asyncio.get_event_loop()
-    loop.create_task(redis_listener())
-    yield
-    print("Application shutdown")
-
-app = FastAPI(lifespan=lifespan)
-
-
-# WebSocket 연결 관리 클래스
-class ConnectionManager:
-    def __init__(self):
-        self.active_connections: dict[int, list[WebSocket]] = {}
-
-    async def connect(self, websocket: WebSocket, property_id: int):
-        await websocket.accept()
-        if property_id not in self.active_connections:
-            self.active_connections[property_id] = []
-        self.active_connections[property_id].append(websocket)
-        print(f"WebSocket 연결 성공: property_id={property_id}")
-
-    def disconnect(self, websocket: WebSocket, property_id: int):
-        if property_id in self.active_connections:
-            self.active_connections[property_id].remove(websocket)
-            if not self.active_connections[property_id]:
-                del self.active_connections[property_id]
-            print(f"WebSocket 연결 종료: property_id={property_id}")
-
-    async def broadcast(self, message: str, property_id: int):
-        if property_id in self.active_connections:
-            print(f"Broadcasting message to {len(self.active_connections[property_id])} clients for property_id {property_id}")
-            for connection in self.active_connections[property_id]:
-                try:
-                    await connection.send_text(message)
-                except Exception as e:
-                    print(f"Error sending message to WebSocket client: {e}")
-
-
-# WebSocket 연결 관리 인스턴스 생성
-manager = ConnectionManager()
-
-@app.websocket("/api/ws/orders/{property_id}")
-async def websocket_endpoint(websocket: WebSocket, property_id: int):
-    await manager.connect(websocket, property_id)
-    try:
-        while True:
-            data = await websocket.receive_text()  # WebSocket 연결 유지
-            print(f"Received WebSocket message from client: {data}")
-    except WebSocketDisconnect:
-        manager.disconnect(websocket, property_id)
-    except Exception as e:
-        print(f"WebSocket error: {e}")
-
-
-# Redis Pub/Sub Listener
-async def redis_listener():
-    pubsub = redis_client.pubsub()
-    pubsub.subscribe("order_book_updates")
-    print("Redis listener started, subscribed to 'order_book_updates'")
-    try:
-        while True:
-            message = pubsub.get_message()
-            if message and message["type"] == "message":
-                data = json.loads(message["data"])
-                property_id = data.get("property_id")
-                print(f"Redis message received: {data}")
-                if property_id:
-                    await manager.broadcast(json.dumps(data), property_id)
-            await asyncio.sleep(0.01)  # Redis 메시지 폴링 간격
-    except Exception as e:
-        print(f"Redis listener error: {e}")
-
-
-# Redis 데이터 업데이트 및 Pub/Sub 메시지 발행
-def update_order_book_in_redis(property_id: int, order_book: dict):
-    redis_key = f"order_book:{property_id}"
-    redis_client.hset(redis_key, "order_book", json.dumps(order_book))
-
-    # Pub/Sub 메시지 발행
-    update_message = {"property_id": property_id, "order_book": order_book}
-    print(f"Publishing Redis message: {update_message}")
-    redis_client.publish("order_book_updates", json.dumps(update_message))
-
-# JWT 인증 함수
-def verify_jwt(token: str):
-    try:
-        decoded = jwt.decode(token, JWT_SECRET_KEY, algorithms=["HS256"])
-        return decoded["user_id"]
-    except jwt.ExpiredSignatureError:
-        raise HTTPException(status_code=401, detail="Token expired")
-    except jwt.InvalidTokenError:
-        raise HTTPException(status_code=401, detail="Invalid token")    
-    
-# Pydantic 모델
+# Pydantic 모델 정의
 class BuyOrderRequest(BaseModel):
     quantity: int
     price_per_token: int
@@ -133,16 +19,13 @@ class SellOrderRequest(BaseModel):
     quantity: int
     price_per_token: int
 
-
-
 # 주문 제출 API (매수)
-@app.post("/api/orders/{property_id}/buy")
+@router.post("/{property_id}/buy")
 async def submit_buy_order(order: BuyOrderRequest, property_id: int):
     # TODO: JWT에서 유저 ID 가져오기
     user_id = 1
-
     try:
-        conn = pymysql.connect(**db_config)
+        conn = pymysql.connect(**DB_CONFIG)
         cursor = conn.cursor()
 
         # TODO: 1. 사용자 잔액 확인
@@ -159,36 +42,30 @@ async def submit_buy_order(order: BuyOrderRequest, property_id: int):
         cursor.execute(query, (
             property_id, user_id, "buy", order.price_per_token, order.quantity, order.quantity, "normal"))
         conn.commit()
-
         order_id = cursor.lastrowid
 
         # 3. Redis 호가창 업데이트
         redis_key = f"order_book:{property_id}"
-        existing_order_book = redis_client.hget(redis_key, "order_book")
+        existing_order_book = REDIS_CLIENT.hget(redis_key, "order_book")
         order_book = json.loads(existing_order_book) if existing_order_book else {"buy": {}, "sell": {}}
         if str(order.price_per_token) not in order_book["buy"]:
             order_book["buy"][str(order.price_per_token)] = []
         order_book["buy"][str(order.price_per_token)].append({"order_id": order_id, "quantity": order.quantity})
-
         update_order_book_in_redis(property_id, order_book)
-
     except pymysql.MySQLError as e:
         raise HTTPException(status_code=500, detail=f"DB 에러: {e}")
     finally:
         cursor.close()
         conn.close()
-
     return {"message": "매수 주문이 완료", "order_id": order_id}
 
-
 # 주문 제출 API (매도)
-@app.post("/api/orders/{property_id}/sell")
+@router.post("/{property_id}/sell")
 async def submit_sell_order(order: SellOrderRequest, property_id: int):
     # TODO: JWT에서 유저 ID 가져오기
     user_id = 1
-
     try:
-        conn = pymysql.connect(**db_config)
+        conn = pymysql.connect(**DB_CONFIG)
         cursor = conn.cursor()
 
         # TODO: 1. 사용자의 보유 토큰 확인
@@ -204,36 +81,29 @@ async def submit_sell_order(order: SellOrderRequest, property_id: int):
         cursor.execute(query, (
             property_id, user_id, "sell", order.price_per_token, order.quantity, order.quantity, "normal"))
         conn.commit()
-
         order_id = cursor.lastrowid
 
         # 3. Redis 호가창 업데이트
         redis_key = f"order_book:{property_id}"
-        existing_order_book = redis_client.hget(redis_key, "order_book")
+        existing_order_book = REDIS_CLIENT.hget(redis_key, "order_book")
         order_book = json.loads(existing_order_book) if existing_order_book else {"buy": {}, "sell": {}}
         if str(order.price_per_token) not in order_book["sell"]:
             order_book["sell"][str(order.price_per_token)] = []
         order_book["sell"][str(order.price_per_token)].append({"order_id": order_id, "quantity": order.quantity})
-
         update_order_book_in_redis(property_id, order_book)
-
     except pymysql.MySQLError as e:
         raise HTTPException(status_code=500, detail=f"DB 에러: {e}")
     finally:
         cursor.close()
         conn.close()
-
     return {"message": "매도 주문이 완료", "order_id": order_id}
 
-
-# REST API: 호가창 데이터 조회
-@app.get("/api/orders/{property_id}")
+# REST API: 호가창 조회
+@router.get("/{property_id}")
 async def get_order_book(property_id: int):
     redis_key = f"order_book:{property_id}"
-
     # Redis에서 전체 order_book 조회
-    existing_order_book = redis_client.hget(redis_key, "order_book")  # HGET 사용
-
+    existing_order_book = REDIS_CLIENT.hget(redis_key, "order_book")
     if existing_order_book:
         try:
             order_book = json.loads(existing_order_book)  # JSON 디코딩
@@ -241,11 +111,53 @@ async def get_order_book(property_id: int):
             raise HTTPException(status_code=500, detail="Redis 데이터 디코딩 실패.")
     else:
         order_book = {"sell": {}, "buy": {}}
-        redis_client.hset(redis_key, "order_book", json.dumps(order_book))  # Redis에 저장
-
+        REDIS_CLIENT.hset(redis_key, "order_book", json.dumps(order_book))  # Redis에 저장
     return {"property_id": property_id, "order_book": order_book}
 
 
-if __name__ == "__main__":
-    import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+# Redis Pub/Sub Listener
+async def redis_listener():
+    # Redis 채널 구독
+    pubsub = REDIS_CLIENT.pubsub()
+    pubsub.subscribe("order_book_updates")
+    print("Redis listener started, subscribed to 'order_book_updates'")
+    try:
+        while True:
+            # Redis에서 메시지 수신
+            message = pubsub.get_message()
+            if message and message["type"] == "message":
+                data = json.loads(message["data"])
+                property_id = data.get("property_id")
+                if property_id:
+                    # WebSocket으로 브로드캐스트
+                    await manager.broadcast(json.dumps(data), property_id)
+            await asyncio.sleep(0.01)  # Redis 메시지 폴링 간격
+    except Exception as e:
+        print(f"Redis listener error: {e}")
+
+# Redis 데이터 업데이트 및 Pub/Sub 메시지 발행
+def update_order_book_in_redis(property_id: int, order_book: dict):
+    redis_key = f"order_book:{property_id}"
+    REDIS_CLIENT.hset(redis_key, "order_book", json.dumps(order_book))
+    update_message = {"property_id": property_id, "order_book": order_book}
+    REDIS_CLIENT.publish("order_book_updates", json.dumps(update_message))
+
+
+
+
+
+# # FastAPI 앱 생성
+# @asynccontextmanager
+# async def lifespan(app: FastAPI):
+#     print("Application startup")
+#     loop = asyncio.get_event_loop()
+#     loop.create_task(redis_listener())
+#     yield
+#     print("Application shutdown")
+#
+# app = FastAPI(lifespan=lifespan)
+# app.include_router(router, prefix="/api", tags=["orders"])
+#
+# if __name__ == "__main__":
+#     import uvicorn
+#     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/domain/order/order_matching_scheduler.py
+++ b/domain/order/order_matching_scheduler.py
@@ -1,0 +1,110 @@
+import asyncio
+import json
+import redis
+from datetime import datetime
+import os
+from dotenv import load_dotenv
+
+# 환경 변수 로드
+load_dotenv()
+
+# Redis 설정
+redis_client = redis.Redis(
+    host=os.getenv("REDIS_HOST"),
+    port=int(os.getenv("REDIS_PORT")),
+    db=int(os.getenv("REDIS_DB")),
+    decode_responses=True
+)
+
+
+# 단일가 매매 함수
+def match_orders(property_id: int):
+    redis_key = f"order_book:{property_id}"
+    order_book_data = redis_client.hget(redis_key, "order_book")
+
+    if not order_book_data:
+        print(f"[{datetime.now()}] 호가창에 주문이 없습니다.")
+        return
+
+    # 호가창 데이터 로드
+    order_book = json.loads(order_book_data)
+    buy_orders = order_book.get("buy", {})
+    sell_orders = order_book.get("sell", {})
+
+    print(f"[{datetime.now()}] 단일가 매매 실행: property_id={property_id}")
+
+    # 매수/매도 가격 정렬
+    sorted_buy_prices = sorted(buy_orders.keys(), key=lambda x: int(x), reverse=True)  # 높은 가격 우선
+    sorted_sell_prices = sorted(sell_orders.keys(), key=lambda x: int(x))  # 낮은 가격 우선
+
+    trades = []  # 체결 내역
+
+    # 매칭 로직
+    while sorted_buy_prices and sorted_sell_prices:
+        highest_buy_price = int(sorted_buy_prices[0])
+        lowest_sell_price = int(sorted_sell_prices[0])
+
+        if highest_buy_price >= lowest_sell_price:  # 매칭 조건
+            buy_orders_at_price = buy_orders[str(highest_buy_price)]
+            sell_orders_at_price = sell_orders[str(lowest_sell_price)]
+
+            buy_order = buy_orders_at_price[0]  # FIFO 방식
+            sell_order = sell_orders_at_price[0]
+
+            matched_quantity = min(buy_order["quantity"], sell_order["quantity"])
+
+            # 체결 기록
+            trades.append({
+                "price": lowest_sell_price,
+                "quantity": matched_quantity,
+                "buy_order_id": buy_order["order_id"],
+                "sell_order_id": sell_order["order_id"]
+            })
+
+            # 주문 수량 업데이트
+            buy_order["quantity"] -= matched_quantity
+            sell_order["quantity"] -= matched_quantity
+
+            # 완료된 주문 제거
+            if buy_order["quantity"] == 0:
+                buy_orders_at_price.pop(0)
+                if not buy_orders_at_price:
+                    del buy_orders[str(highest_buy_price)]
+                    sorted_buy_prices.pop(0)
+
+            if sell_order["quantity"] == 0:
+                sell_orders_at_price.pop(0)
+                if not sell_orders_at_price:
+                    del sell_orders[str(lowest_sell_price)]
+                    sorted_sell_prices.pop(0)
+
+        else:
+            break  # 매칭 불가 상태
+
+    # Redis 호가창 업데이트
+    order_book["buy"] = buy_orders
+    order_book["sell"] = sell_orders
+    redis_client.hset(redis_key, "order_book", json.dumps(order_book))
+
+    # 매칭 결과 출력
+    if trades:
+        print(f"[{datetime.now()}] 체결 내역:")
+        for trade in trades:
+            print(trade)
+    else:
+        print(f"[{datetime.now()}] 매칭된 주문이 없습니다.")
+
+
+# 단일가 매매 스케줄러
+async def periodic_matching(interval: int = 300):
+    while True:
+        #match_orders(property_id)
+        match_orders(5)
+        await asyncio.sleep(interval)
+
+
+# 메인 실행
+if __name__ == "__main__":
+    property_id = 6  # 특정 property_id 설정
+    print(f"단일가 매매 스크립트 실행 중... property_id={property_id}")
+    asyncio.run(periodic_matching(property_id))

--- a/domain/order/order_socket.py
+++ b/domain/order/order_socket.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from core.websockets import manager
+
+# 라우터 생성
+router = APIRouter()
+
+# WebSocket 엔드포인트
+@router.websocket("/{property_id}")
+async def websocket_endpoint(websocket: WebSocket, property_id: int):
+    await manager.connect(websocket, property_id)
+    try:
+        while True:
+            data = await websocket.receive_text()  # WebSocket 연결 유지
+            print(f"Received WebSocket message from client: {data}")
+    except WebSocketDisconnect:
+        manager.disconnect(websocket, property_id)
+    except Exception as e:
+        print(f"WebSocket error: {e}")

--- a/domain/user/login.py
+++ b/domain/user/login.py
@@ -1,23 +1,12 @@
 from fastapi import HTTPException, APIRouter, Response
 from pydantic import BaseModel
-from passlib.context import CryptContext
-from datetime import datetime, timedelta
-import jwt
-
+from core.jwt import create_access_token
 from core.mysql_connector import DB
-
-# JWT 및 비밀번호 설정
-SECRET_KEY = "your_secret_key"
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 # 라우터 초기화
 router = APIRouter()
 
 # Pydantic 모델
-
-
 class User(BaseModel):
     name: str
     phone: str
@@ -25,15 +14,6 @@ class User(BaseModel):
 
 class LoginRequest(BaseModel):
     phone: str
-
-
-# JWT 토큰 생성 함수
-def create_access_token(data: dict, expires_delta: timedelta = None):
-    to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
-    to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
-    return encoded_jwt
 
 
 # 회원가입 API
@@ -68,22 +48,22 @@ def login(login_request: LoginRequest, db_conn: DB, response: Response):
 
     # 입력된 phone의 사용자 데이터 확인
     check_user_query = '''
-        SELECT username, phone FROM Users WHERE phone = %s
+        SELECT id FROM Users WHERE phone = %s
     '''
     cursor.execute(check_user_query, (login_request.phone,))
     db_user = cursor.fetchone()
 
     if db_user:
         # 로그인 성공 시 토큰 생성
-        access_token = create_access_token(data={"sub": db_user["username"]})
+        access_token = create_access_token(user_id=db_user["id"])
         response.set_cookie(
             key="access_token",
-            value=f"Bearer {access_token}",
+            value=access_token,
             httponly=True,
-            max_age=ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+            max_age=30 * 60,  # 30분 (JWT 기본 만료 시간)
             samesite="lax",
         )
-        return {"message": "Login successful!", "user": {"username": db_user["username"]}}
+        return {"message": "Login successful!", "user": {"id": db_user["id"]}}
     else:
         # 번호가 존재하지 않을 경우 기존 로직 수행
         raise HTTPException(status_code=400, detail="Invalid phone number")

--- a/main.py
+++ b/main.py
@@ -7,9 +7,9 @@ from domain.apartments.getTotalApartInfo import router as total_router
 from domain.apartments.saveForm import router as form_router
 from domain.user.login import router as auth_router
 from domain.order.main import router as order_router
-from domain.order.main import redis_listener
 from domain.order.order_socket import router as order_socket_router
 from domain.order.order_matching_scheduler import periodic_matching
+from core.redis import redis_listener
 import asyncio
 import requests
 import os

--- a/main.py
+++ b/main.py
@@ -6,8 +6,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from domain.apartments.getTotalApartInfo import router as total_router
 from domain.apartments.saveForm import router as form_router
 from domain.user.login import router as auth_router
-
-
+from domain.order.main import router as order_router
+from domain.order.main import redis_listener
+from domain.order.order_socket import router as order_socket_router
+from domain.order.order_matching_scheduler import periodic_matching
+import asyncio
 import requests
 import os
 
@@ -31,6 +34,19 @@ app.include_router(form_router,prefix="/api",tags=["apartments"])
 
 app.include_router(auth_router, prefix='/api',
                    tags=['auth'])
+
+app.include_router(order_router, prefix="/api/orders", tags=["order"])
+app.include_router(order_socket_router, prefix="/api/ws/orders", tags=["order_socket"])
+
+
+# 애플리케이션 시작 시 Redis Listener와 스케줄러 실행
+@app.on_event("startup")
+async def startup_event():
+    loop = asyncio.get_event_loop()
+    # Redis Listener 실행
+    loop.create_task(redis_listener())
+    # 스케줄러 실행
+    loop.create_task(periodic_matching(interval=300))
 
 
 @app.get("/")


### PR DESCRIPTION
## 개요

- 로그인 기능과 매수/매도 주문 기능을 리팩토링하여 모듈화 작업을 진행
- 루트 폴더의 메인에 관련 로직을 통합 연결

## 작업사항

#15

## 변경로직

1. **로그인 기능 변경**
   - JWT 관련 로직을 모듈화하여 `core/jwt.py` 에 별도 파일로 분리
   - JWT에 저장하는 정보를 username에서 id로 변경

2. **매수/매도 주문 로직 변경**
   - DB와 redis관련 연결 로직을 `core/settings.py`에 별도 파일로 분리
   - redis pub/sub관련 로직을 `core/redis.py`에 별도 파일로 분리
   - 웹 소켓 관련 로직을 `core/websockets.py`에 별도 파일로 분리
   - `order/main.py`에 있는 API를 루트폴더의 main.py에 연결
