### PR TITLE
사용자 주문 화면 데이터 제공 API 구현

### DIFF
--- a/domain/user/user_order_balance_api.py
+++ b/domain/user/user_order_balance_api.py
@@ -1,0 +1,91 @@
+from fastapi import APIRouter, HTTPException, Request
+from core.settings import DB_CONFIG
+from core.jwt import extract_user_id
+import pymysql
+
+# 라우터 생성
+router = APIRouter()
+
+# 주문가능금액 반환 API
+@router.get("/buy-order-balance")
+async def get_user_orderable_balance(request: Request):
+    # JWT에서 유저 ID 추출
+    token = request.cookies.get("access_token")
+    if not token:
+        raise HTTPException(status_code=401, detail="쿠키에 JWT 없음")
+
+    try:
+        user_id = extract_user_id(token)
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=f"유효하지 않은 토큰: {e}")
+
+    try:
+        conn = pymysql.connect(**DB_CONFIG)
+        cursor = conn.cursor()
+
+        # Users 테이블에서 유저의 보유금액(total_balance)와 주문가능금액(orderable_balance) 조회
+        cursor.execute(
+            "SELECT total_balance, orderable_balance FROM Users WHERE id = %s",
+            (user_id,)
+        )
+        result = cursor.fetchone()
+
+        if not result:
+            raise HTTPException(status_code=404, detail="유저 정보를 찾을 수 없습니다.")
+
+        total_balance, orderable_balance = result
+    except pymysql.MySQLError as e:
+        raise HTTPException(status_code=500, detail=f"DB 에러: {e}")
+    finally:
+        cursor.close()
+        conn.close()
+
+    return {
+        "user_id": user_id,
+        "total_balance": total_balance,
+        "orderable_balance": orderable_balance,
+    }
+
+# 거래가능토큰 반환 API
+@router.get("/sell-order-balance/{property_id}")
+async def get_user_tradeable_tokens(property_id: int, request: Request):
+    # JWT에서 유저 ID 추출
+    token = request.cookies.get("access_token")
+    if not token:
+        raise HTTPException(status_code=401, detail="쿠키에 JWT 없음")
+
+    try:
+        user_id = extract_user_id(token)
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=f"유효하지 않은 토큰: {e}")
+
+    try:
+        conn = pymysql.connect(**DB_CONFIG)
+        cursor = conn.cursor()
+
+        # Ownerships 테이블에서 유저의 특정 방에 대한 거래가능토큰(tradeable_tokens) 조회
+        cursor.execute(
+            """
+            SELECT tradeable_tokens 
+            FROM Ownerships 
+            WHERE user_id = %s AND property_detail_id = %s
+            """,
+            (user_id, property_id)
+        )
+        result = cursor.fetchone()
+
+        if not result:
+            raise HTTPException(status_code=404, detail="거래가능토큰 정보를 찾을 수 없습니다.")
+
+        tradeable_tokens = result[0]
+    except pymysql.MySQLError as e:
+        raise HTTPException(status_code=500, detail=f"DB 에러: {e}")
+    finally:
+        cursor.close()
+        conn.close()
+
+    return {
+        "user_id": user_id,
+        "property_id": property_id,
+        "tradeable_tokens": tradeable_tokens,
+    }

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from domain.apartments.getTotalApartInfo import router as total_router
 from domain.apartments.saveForm import router as form_router
 from domain.user.login import router as auth_router
+from domain.user.user_order_balance_api import router as order_balance_router
 from domain.order.main import router as order_router
 from domain.order.order_socket import router as order_socket_router
 from domain.order.order_matching_scheduler import periodic_matching
@@ -39,6 +40,8 @@ app.include_router(auth_router, prefix='/api',
 
 app.include_router(order_router, prefix="/api/orders", tags=["order"])
 app.include_router(order_socket_router, prefix="/api/ws/orders", tags=["order_socket"])
+
+app.include_router(order_balance_router, prefix="/api/users", tags=["order_balance_router"])
 
 
 # 애플리케이션 시작 시 Redis Listener와 스케줄러 실행


### PR DESCRIPTION
## 개요

사용자 주문 화면 데이터 제공 API 구현

## 작업사항

#20 

## 변경로직
<img width="555" alt="image" src="https://github.com/user-attachments/assets/0389a5cb-304c-4a24-be9e-f114a8d6fe43">

- **매수 주문 화면 API 구현**:
  - `Users` 테이블에서 `user_id`를 기준으로 사용자의 `orderable_balance`(주문가능금액)를 반환하는 API를 추가
  
- **매도 주문 화면 API 구현**:
  - `Ownerships` 테이블에서 `user_id`와 `property_id`를 기준으로 사용자의 `tradeable_tokens`(거래가능토큰수)를 반환하는 API를 추가

- **라우터 연결**:
  - 위 API들을 메인 앱에 연결하여 `/api/users` 경로에서 사용할 수 있도록 설정
