### PR TITLE
건물 단일가매매 기록 조회 API 구현

### DIFF
--- a/domain/properties/property_history.py
+++ b/domain/properties/property_history.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, HTTPException
+from core.settings import DB_CONFIG
+import pymysql
+
+# 라우터 생성
+router = APIRouter()
+
+# 건물 단일가매매 기록 조회 API
+@router.get("/{property_id}/history")
+async def get_property_history(property_id: int):
+    try:
+        conn = pymysql.connect(**DB_CONFIG)
+        cursor = conn.cursor()
+
+        # 최신 날짜 기준으로 100개 조회
+        query = """
+            SELECT recorded_date, price, quantity
+            FROM Property_History
+            WHERE property_detail_id = %s
+            ORDER BY recorded_date DESC
+            LIMIT 100
+        """
+
+        cursor.execute(query, (property_id,))
+        results = cursor.fetchall()
+
+        if not results:
+            raise HTTPException(status_code=404, detail="해당 건물의 매매 기록이 없습니다.")
+
+        # 결과 데이터 처리
+        history = [
+            {"recorded_date": str(row[0]), "price": row[1], "quantity": row[2]}
+            for row in results
+        ]
+    except pymysql.MySQLError as e:
+        raise HTTPException(status_code=500, detail=f"DB 에러: {e}")
+    finally:
+        cursor.close()
+        conn.close()
+
+    return {
+        "property_id": property_id,
+        "history": history
+    }

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from domain.order.main import router as order_router
 from domain.order.order_socket import router as order_socket_router
 from domain.order.order_matching_scheduler import periodic_matching
 from domain.buildings.main import router as buildings_router
+from domain.properties.property_history import router as property_history_router
 from core.redis import redis_listener
 import asyncio
 import requests
@@ -40,6 +41,7 @@ app.include_router(auth_router, prefix='/api',
 app.include_router(order_router, prefix="/api/orders", tags=["order"])
 app.include_router(order_socket_router, prefix="/api/ws/orders", tags=["order_socket"])
 
+app.include_router(property_history_router, prefix="/api/properties", tags=["property_history_router"])
 
 # 애플리케이션 시작 시 Redis Listener와 스케줄러 실행
 @app.on_event("startup")


### PR DESCRIPTION
## 개요

- 건물 단일가매매 기록 조회 API 구현 (최신 100개 기록 반환)

## 작업사항

#21 

## 변경로직
<img width="571" alt="image" src="https://github.com/user-attachments/assets/c80754ec-bf6b-47fc-986e-c8c3d7abd831">

- **단일가매매 기록 조회 API 구현**:
  - 특정 건물(`property_id`)의 매매 기록을 반환하는 API 추가
  - `Property_History` 테이블에서 `recorded_date`, `price`, `quantity` 데이터를 최신순으로 조회
  - 최대 100개의 최신 데이터를 반환하도록 구현
  - `/properties/{property_id}/history` 엔드포인트 생성

- **라우터 연결**:
  - 구현된 API를 메인 애플리케이션에 라우터로 연결하여 사용할 수 있도록 설정
