### PR TITLE
사용자 보유 토큰 조회 API 구현

### DIFF
--- a/domain/ownerships/ownerships.py
+++ b/domain/ownerships/ownerships.py
@@ -1,0 +1,57 @@
+from fastapi import APIRouter, HTTPException, Request
+from core.settings import DB_CONFIG
+from core.jwt import extract_user_id
+import pymysql
+
+# 라우터 생성
+router = APIRouter()
+
+# 사용자 보유 토큰 반환 API
+@router.get("/")
+async def get_user_ownerships(request: Request):
+    # JWT에서 유저 ID 추출
+    token = request.cookies.get("access_token")
+    if not token:
+        raise HTTPException(status_code=401, detail="쿠키에 JWT 없음")
+
+    try:
+        user_id = extract_user_id(token)
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=f"유효하지 않은 토큰: {e}")
+
+    try:
+        conn = pymysql.connect(**DB_CONFIG)
+        cursor = conn.cursor()
+
+        # Ownerships 테이블에서 유저의 보유 토큰 정보 조회
+        cursor.execute(
+            """
+            SELECT property_detail_id, quantity, buy_price 
+            FROM Ownerships 
+            WHERE user_id = %s
+            """,
+            (user_id,)
+        )
+        results = cursor.fetchall()
+
+        if not results:
+            raise HTTPException(status_code=404, detail="보유 토큰 정보를 찾을 수 없습니다.")
+
+        ownerships = [
+            {
+                "property_detail_id": row[0],
+                "quantity": row[1],
+                "buy_price": row[2],
+            }
+            for row in results
+        ]
+    except pymysql.MySQLError as e:
+        raise HTTPException(status_code=500, detail=f"DB 에러: {e}")
+    finally:
+        cursor.close()
+        conn.close()
+
+    return {
+        "user_id": user_id,
+        "ownerships": ownerships,
+    }

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from domain.apartments.getTotalApartInfo import router as total_router
 from domain.apartments.saveForm import router as form_router
 from domain.user.login import router as auth_router
 from domain.user.user_order_balance_api import router as order_balance_router
+from domain.ownerships.ownerships import router as ownerships_router
 from domain.order.main import router as order_router
 from domain.order.order_cancel import router as order_cancel_router
 from domain.order.order_socket import router as order_socket_router
@@ -46,6 +47,7 @@ app.include_router(order_socket_router, prefix="/api/ws/orders", tags=["order_so
 
 app.include_router(property_history_router, prefix="/api/properties", tags=["property_history_router"])
 app.include_router(order_balance_router, prefix="/api/users", tags=["order_balance_router"])
+app.include_router(ownerships_router, prefix="/api/ownerships", tags=["ownerships_router"])
 
 # 애플리케이션 시작 시 Redis Listener와 스케줄러 실행
 @app.on_event("startup")


### PR DESCRIPTION
## 개요

- 사용자 보유 토큰 조회 API 구현

## 작업사항

- #23 

## 변경로직

- **Endpoint**: `/api/users/ownerships`
- **Method**: `GET`
- JWT에서 사용자 ID를 추출하여 `Ownerships` 테이블에서 사용자 보유 토큰 정보를 조회.
- 반환 데이터:
  - `property_detail_id`
  - `quantity`
  - `buy_price`
