### PR TITLE
사용자 주문 기록 조회 API

### DIFF
--- a/domain/archives/archives.py
+++ b/domain/archives/archives.py
@@ -1,0 +1,75 @@
+from fastapi import APIRouter, HTTPException, Request, Query
+from core.settings import DB_CONFIG
+from core.jwt import extract_user_id
+import pymysql
+
+# 라우터 생성
+router = APIRouter()
+
+# 사용자 주문 기록 조회 API
+@router.get("/")
+async def get_user_order_archives(
+        request: Request,
+        status: str = Query(None, description="조회할 주문 상태 (예: 'normal', 'cancelled', 'fulfilled')")
+):
+    # JWT에서 유저 ID 추출
+    token = request.cookies.get("access_token")
+    if not token:
+        raise HTTPException(status_code=401, detail="쿠키에 JWT 없음")
+
+    try:
+        user_id = extract_user_id(token)
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=f"유효하지 않은 토큰: {e}")
+
+    try:
+        conn = pymysql.connect(**DB_CONFIG)
+        cursor = conn.cursor()
+
+        # 주문 상태별로 필터링하여 주문 기록 조회
+        if status:
+            cursor.execute(
+                """
+                SELECT order_type, price_per_token, quantity, status, created_at 
+                FROM Order_Archive 
+                WHERE user_id = %s AND status = %s
+                ORDER BY created_at DESC
+                """,
+                (user_id, status)
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT order_type, price_per_token, quantity, status, created_at 
+                FROM Order_Archive 
+                WHERE user_id = %s
+                ORDER BY created_at DESC
+                """,
+                (user_id,)
+            )
+
+        results = cursor.fetchall()
+
+        if not results:
+            raise HTTPException(status_code=404, detail="주문 기록을 찾을 수 없습니다.")
+
+        orders = [
+            {
+                "order_type": row[0],
+                "price_per_token": row[1],
+                "quantity": row[2],
+                "status": row[3],
+                "created_at": row[4],
+            }
+            for row in results
+        ]
+    except pymysql.MySQLError as e:
+        raise HTTPException(status_code=500, detail=f"DB 에러: {e}")
+    finally:
+        cursor.close()
+        conn.close()
+
+    return {
+        "user_id": user_id,
+        "orders": orders,
+    }

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from domain.order.order_socket import router as order_socket_router
 from domain.order.order_matching_scheduler import periodic_matching
 from domain.buildings.main import router as buildings_router
 from domain.properties.property_history import router as property_history_router
+from domain.archives.archives import router as archives_router
 from core.redis import redis_listener
 import asyncio
 import requests
@@ -46,6 +47,8 @@ app.include_router(order_socket_router, prefix="/api/ws/orders", tags=["order_so
 
 app.include_router(property_history_router, prefix="/api/properties", tags=["property_history_router"])
 app.include_router(order_balance_router, prefix="/api/users", tags=["order_balance_router"])
+
+app.include_router(archives_router, prefix="/api/order_archives", tags=["archives_router"])
 
 # 애플리케이션 시작 시 Redis Listener와 스케줄러 실행
 @app.on_event("startup")


### PR DESCRIPTION
## 개요

- 사용자 주문 기록 조회 API 구현

## 작업사항

- #22 

### 사용자 주문 기록 조회 API 구현

1. **API Endpoint**: 
   - **URL**: `/api/order_archives`
   - **Method**: `GET`

2. **기능**:
   - JWT 인증을 통해 사용자 식별.
   - `Order_Archive` 테이블에서 `user_id`를 기준으로 주문 데이터를 조회.
   - 쿼리 파라미터 `status`를 사용하여 특정 주문 상태(`normal`, `cancelled`, `fulfilled`)별로 필터링 가능.

3. **반환 데이터**:
   - 각 주문 기록의 필드는 다음과 같습니다:
     - `order_type`: 주문 유형 (예: 매수, 매도)
     - `price_per_token`: 토큰당 가격
     - `quantity`: 주문 수량
     - `status`: 주문 상태 (`normal`, `cancelled`, `fulfilled`)
     - `created_at`: 주문 생성 시각