### PR TITLE
사용자 주문 기록, 미체결 주문 및 보유 종목 API 확장

### DIFF
--- a/ddl
+++ b/ddl
@@ -22,6 +22,24 @@ CREATE TABLE Property_Detail (
     PRIMARY KEY (id)
 ) COMMENT='건물 매물 정보';
 
+CREATE TABLE Building (
+    id BIGINT NOT NULL COMMENT '건물id',
+    name VARCHAR(100) NOT NULL COMMENT '건물이름',
+    token_supply INT NOT NULL COMMENT '건물에 할당된 총 토큰 수',
+    created_at DATETIME NOT NULL COMMENT '건물등록시간',
+    price FLOAT NULL COMMENT '최근 거래된 가격',
+    address VARCHAR(100) NOT NULL COMMENT '건물실주소',
+    building_code VARCHAR(100) NOT NULL COMMENT '건물주소 코드',
+    platArea VARCHAR(100) NOT NULL COMMENT '대지면적',
+    bcRat VARCHAR(100) NOT NULL COMMENT '건폐율',
+    totArea VARCHAR(100) NOT NULL COMMENT '연면적',
+    vlRat VARCHAR(100) NOT NULL COMMENT '용적률',
+    property_photo VARCHAR(100) NULL COMMENT '대표사진 [static경로.jpeg]',
+    Lat FLOAT NULL COMMENT '위도',
+    Lng FLOAT NULL COMMENT '경도',
+    PRIMARY KEY (id)
+) COMMENT='건물 정보 테이블';
+
 CREATE TABLE Ownerships (
     id BIGINT AUTO_INCREMENT NOT NULL COMMENT '소유내역id',
     quantity INT NULL COMMENT '소유량',

--- a/domain/archives/archives.py
+++ b/domain/archives/archives.py
@@ -30,20 +30,40 @@ async def get_user_order_archives(
         if status:
             cursor.execute(
                 """
-                SELECT order_type, price_per_token, quantity, status, created_at 
-                FROM Order_Archive 
-                WHERE user_id = %s AND status = %s
-                ORDER BY created_at DESC
+                SELECT 
+                    oa.id,
+                    oa.order_type, 
+                    oa.price_per_token, 
+                    oa.quantity, 
+                    oa.status, 
+                    oa.created_at,
+                    pd.detail_floor,
+                    b.name AS building_name
+                FROM Order_Archive oa
+                LEFT JOIN Property_Detail pd ON oa.property_detail_id = pd.id
+                LEFT JOIN Building b ON pd.property_id = b.id
+                WHERE oa.user_id = %s AND oa.status = %s
+                ORDER BY oa.created_at DESC
                 """,
                 (user_id, status)
             )
         else:
             cursor.execute(
                 """
-                SELECT order_type, price_per_token, quantity, status, created_at 
-                FROM Order_Archive 
-                WHERE user_id = %s
-                ORDER BY created_at DESC
+                SELECT 
+                    oa.id,
+                    oa.order_type, 
+                    oa.price_per_token, 
+                    oa.quantity, 
+                    oa.status, 
+                    oa.created_at,
+                    pd.detail_floor,
+                    b.name AS building_name
+                FROM Order_Archive oa
+                LEFT JOIN Property_Detail pd ON oa.property_detail_id = pd.id
+                LEFT JOIN Building b ON pd.property_id = b.id
+                WHERE oa.user_id = %s
+                ORDER BY oa.created_at DESC
                 """,
                 (user_id,)
             )
@@ -55,11 +75,14 @@ async def get_user_order_archives(
 
         orders = [
             {
-                "order_type": row[0],
-                "price_per_token": row[1],
-                "quantity": row[2],
-                "status": row[3],
-                "created_at": row[4],
+                "id": row[0],
+                "order_type": row[1],
+                "price_per_token": row[2],
+                "quantity": row[3],
+                "status": row[4],
+                "created_at": row[5],
+                "detail_floor": row[6],
+                "building_name": row[7],
             }
             for row in results
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ exceptiongroup==1.2.2
 fastapi==0.115.5
 h11==0.14.0
 idna==3.10
-jwt==1.3.1
+PyJWT==2.10.1
 lxml==5.3.0
 numpy==2.0.2
 pandas==2.2.3
@@ -39,3 +39,8 @@ urllib3==2.2.3
 uvicorn==0.32.0
 websockets==14.1
 xmltodict==0.14.2
+openai==1.55.3
+httpx==0.28.0
+httpcore==1.0.7
+jiter==0.8.0
+tqdm==4.67.1


### PR DESCRIPTION
## 개요

- 사용자 주문 기록, 미체결 주문, 보유 종목 관련 API에 `building_name`(건물 이름)과 `detail_floor`(층수) 정보를 추가하여 데이터 활용성과 가독성을 개선.

## 작업사항

#32

## 변경로직

- 사용자 주문 기록 및 미체결 주문 API에서 `building_name`과 `detail_floor` 필드 반환 기능 추가.
- 보유 종목 관련 API에서 `building_name`과 `detail_floor` 필드 반환 기능 추가.