### PR TITLE
토큰 청약 기능 구현 

### DIFF
--- a/domain/apartments/saveForm.py
+++ b/domain/apartments/saveForm.py
@@ -17,7 +17,7 @@ load_dotenv()
 SERVICE_KEY = os.getenv("PUBLIC_DATA_API_KEY")
 
 # API basic URL
-BUILDING_BASE_URL = "https://apis.data.go.kr/1613000/BldRgstHubService/getBrRecapTitleInfo"
+BUILDING_BASE_URL = "http://apis.data.go.kr/1613000/BldRgstHubService/getBrRecapTitleInfo"
 
 # Data model for building information
 class BuildingInfo(BaseModel):

--- a/domain/subscription/main.py
+++ b/domain/subscription/main.py
@@ -1,0 +1,80 @@
+from fastapi import APIRouter, HTTPException, Request;
+from pydantic import BaseModel
+from typing import List
+from fastapi.concurrency import run_in_threadpool
+from core.mysql_connector import get_db_connection
+from datetime import datetime
+import pymysql.cursors
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.schedulers.base import STATE_RUNNING
+import asyncio
+from core.jwt import extract_user_id
+
+router = APIRouter()
+
+# 데이터 모델
+class OwnershipRequest(BaseModel):
+    property_detail_id: int
+    quantity: int
+    tradeable_tokens: int
+    buy_price: float
+    subscription_end_date: datetime
+
+class OwnershipRecord(OwnershipRequest):
+    id: int
+    created_at: str
+
+
+@router.post("/subscribe", response_model=OwnershipRecord)
+async def subscribe(request: OwnershipRequest, jwt: Request):
+    """
+    Subscriptions 테이블에 청약 데이터를 추가
+    """
+     # 쿠키에서 JWT 가져오기
+    token = jwt.cookies.get("access_token")
+    if not token:
+        raise HTTPException(status_code=401, detail="쿠키에 JWT없음")
+
+    # JWT에서 유저 ID 가져오기
+    try:
+        user_id = extract_user_id(token)
+    except ValueError as e:
+        raise HTTPException(status_code=401, detail=f"토큰 유효 X {e}")
+        
+    def insert_subscription():
+        query = """
+            INSERT INTO Subscriptions (user_id, property_detail_id, price_per_token, quantity, status, subscription_end_date)
+            VALUES (%s, %s, %s, %s, 'pending', %s)
+        """
+        values = (
+            user_id,
+            request.property_detail_id,
+            request.buy_price,
+            request.quantity,
+            request.subscription_end_date,
+        )
+        try:
+            with get_db_connection() as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute(query, values)
+                    connection.commit()
+                    return cursor.lastrowid
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Database insertion failed: {e}")
+
+    try:
+        subscription_id = await run_in_threadpool(insert_subscription)
+        return OwnershipRecord(
+            id=subscription_id,
+            user_id=user_id,
+            property_detail_id=request.property_detail_id,
+            quantity=request.quantity,
+            tradeable_tokens=request.tradeable_tokens,
+            buy_price=request.buy_price,
+            subscription_end_date=request.subscription_end_date,
+            created_at="NOW()",
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+

--- a/domain/subscription/main.py
+++ b/domain/subscription/main.py
@@ -1,37 +1,34 @@
-from fastapi import APIRouter, HTTPException, Request;
-from pydantic import BaseModel
-from typing import List
-from fastapi.concurrency import run_in_threadpool
-from core.mysql_connector import get_db_connection
-from datetime import datetime
-import pymysql.cursors
-from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.schedulers.base import STATE_RUNNING
-import asyncio
-from core.jwt import extract_user_id
-
-router = APIRouter()
-
-# 데이터 모델
-class OwnershipRequest(BaseModel):
-    property_detail_id: int
-    quantity: int
-    tradeable_tokens: int
-    buy_price: float
-    subscription_end_date: datetime
-
-class OwnershipRecord(OwnershipRequest):
-    id: int
-    created_at: str
-
-
-@router.post("/subscribe", response_model=OwnershipRecord)
-async def subscribe(request: OwnershipRequest, jwt: Request):
+# 특정 청약 토큰에서 청약이 완료된 토큰 합산하여 반환
+@router.get("/tokens/{property_detail_id}")
+async def get_total_quantity(property_detail_id: int):
     """
-    Subscriptions 테이블에 청약 데이터를 추가
+    특정 property_detail_id에 해당하는 모든 quantity 합산 반환
     """
+    def fetch_total_quantity():
+        query = """
+            SELECT SUM(quantity) AS total_quantity
+            FROM Subscriptions
+            WHERE property_detail_id = %s
+        """
+        try:
+            with get_db_connection() as connection:
+                with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+                    cursor.execute(query, (property_detail_id,))
+                    result = cursor.fetchone()
+                    if result and result['total_quantity'] is not None:
+                        return result['total_quantity']
+                    return 0
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Database query failed: {e}")
+
+    total_quantity = await run_in_threadpool(fetch_total_quantity)
+    return {"property_detail_id": property_detail_id, "total_quantity": total_quantity}
+
+# 사용자 id를 기준으로 청약된 테이블 조회 
+@router.get("/subscriptions")
+async def get_subscriptions(request: Request):
      # 쿠키에서 JWT 가져오기
-    token = jwt.cookies.get("access_token")
+    token = request.cookies.get("access_token")
     if not token:
         raise HTTPException(status_code=401, detail="쿠키에 JWT없음")
 
@@ -40,41 +37,34 @@ async def subscribe(request: OwnershipRequest, jwt: Request):
         user_id = extract_user_id(token)
     except ValueError as e:
         raise HTTPException(status_code=401, detail=f"토큰 유효 X {e}")
-        
-    def insert_subscription():
-        query = """
-            INSERT INTO Subscriptions (user_id, property_detail_id, price_per_token, quantity, status, subscription_end_date)
-            VALUES (%s, %s, %s, %s, 'pending', %s)
-        """
-        values = (
-            user_id,
-            request.property_detail_id,
-            request.buy_price,
-            request.quantity,
-            request.subscription_end_date,
-        )
-        try:
-            with get_db_connection() as connection:
-                with connection.cursor() as cursor:
-                    cursor.execute(query, values)
-                    connection.commit()
-                    return cursor.lastrowid
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=f"Database insertion failed: {e}")
-
+    """
+    특정 사용자 ID를 기준으로 Subscriptions 테이블 조회
+    """
+    query = """
+        SELECT 
+            s.id,
+            s.price_per_token, 
+            s.quantity, 
+            s.status, 
+            s.created_at,
+            pd.detail_floor,
+            b.name AS building_name
+        FROM Subscriptions s
+        LEFT JOIN Property_Detail pd ON s.property_detail_id = pd.id
+        LEFT JOIN Properties b ON pd.property_id = b.id
+        WHERE s.user_id = %s 
+        ORDER BY s.created_at DESC
+    """
     try:
-        subscription_id = await run_in_threadpool(insert_subscription)
-        return OwnershipRecord(
-            id=subscription_id,
-            user_id=user_id,
-            property_detail_id=request.property_detail_id,
-            quantity=request.quantity,
-            tradeable_tokens=request.tradeable_tokens,
-            buy_price=request.buy_price,
-            subscription_end_date=request.subscription_end_date,
-            created_at="NOW()",
-        )
+        with get_db_connection() as connection:
+            with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+                # user_id만으로 조회
+                cursor.execute(query, (user_id))
+                subscriptions = cursor.fetchall()
+                return {"subscriptions": subscriptions}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=f"Database query failed: {e}")
+
+
 
 

--- a/domain/subscription/main.py
+++ b/domain/subscription/main.py
@@ -67,4 +67,81 @@ async def get_subscriptions(request: Request):
 
 
 
+# 스케줄러 초기화
+scheduler = BackgroundScheduler()
 
+from datetime import datetime
+
+def move_subscriptions_to_ownerships():
+    """
+    청약 종료일에 도달한 데이터 중 'pending' 상태인 항목만 Ownerships 테이블로 이동
+    """
+    query_select = """
+        SELECT id, user_id, property_detail_id, quantity, price_per_token
+        FROM Subscriptions
+        WHERE subscription_end_date <= NOW() AND status = 'pending'
+    """
+    query_insert = """
+        INSERT INTO Ownerships (user_id, property_detail_id, quantity, tradeable_tokens, buy_price, created_at)
+        VALUES (%s, %s, %s, %s, %s, %s)
+    """
+    query_update = """
+        UPDATE Subscriptions
+        SET status = 'fulfilled'
+        WHERE id = %s
+    """
+    try:
+        with get_db_connection() as connection:
+            with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+                # 1. 청약 종료일에 도달하고 상태가 'pending'인 데이터 조회
+                cursor.execute(query_select)
+                subscriptions = cursor.fetchall()
+
+                print(f"Found {len(subscriptions)} subscriptions to process.")  # 로그 출력
+
+                for subscription in subscriptions:
+                    try:
+                        # 2. Ownerships 테이블로 데이터 이동
+                        cursor.execute(
+                            query_insert,
+                            (
+                                subscription['user_id'],
+                                subscription['property_detail_id'],
+                                subscription['quantity'],
+                                subscription['quantity'],  # tradeable_tokens
+                                subscription['price_per_token'],
+                                datetime.now(),  # Python에서 현재 시간 추가
+                            ),
+                        )
+                        # 3. Subscriptions 테이블 상태 업데이트
+                        cursor.execute(query_update, (subscription['id'],))
+                        print(f"Processed subscription ID: {subscription['id']}")  # 로그 출력
+                    except Exception as e:
+                        print(f"Error processing subscription ID {subscription['id']}: {e}")
+                        continue
+
+                # 4. 변경사항 커밋
+                connection.commit()
+    except Exception as e:
+        print(f"Error moving subscriptions to ownerships: {e}")
+
+
+# 스케줄러 작업 추가
+if not scheduler.get_jobs():
+    scheduler.add_job(move_subscriptions_to_ownerships, 'interval', hours=24)  
+
+@router.on_event("startup")
+async def startup_event():
+    """
+    FastAPI 앱 시작 시 스케줄러를 시작
+    """
+    if scheduler.state != STATE_RUNNING:  
+        scheduler.start()
+
+@router.on_event("shutdown")
+async def shutdown_event():
+    """
+    FastAPI 앱 종료 시 스케줄러를 종료
+    """
+    if scheduler.state == STATE_RUNNING:
+        scheduler.shutdown()

--- a/main.py
+++ b/main.py
@@ -23,7 +23,8 @@ from domain.side_detail.discussion import router as discussion_router
 # from domain.discussion.websocket import websocket_router
 from domain.properties.property_history import router as property_history_router
 from domain.archives.archives import router as archives_router
-from core.redis import redis_listener
+from domain.subscription.main import router as subscription_router 
+from core.redis import redis_listener 
 import asyncio
 
 import requests
@@ -64,8 +65,7 @@ app.include_router(order_socket_router, prefix="/api/ws/orders", tags=["order_so
 
 app.include_router(property_history_router, prefix="/api/properties", tags=["property_history_router"])
 app.include_router(order_balance_router, prefix="/api/users", tags=["order_balance_router"])
-app.include_router(ownerships_router, prefix="/api/ownerships", tags=["ownerships_router"])
-
+app.include_router(subscription_router, prefix="/api/subscriptions", tags=["subscriptions"])
 app.include_router(archives_router, prefix="/api/order_archives", tags=["archives_router"])
 
 # 애플리케이션 시작 시 Redis Listener와 스케줄러 실행


### PR DESCRIPTION
## 개요
- Subscription 테이블에 청약 데이터를 추가하고, 청약 완료된 토큰 반환 및 마이페이지에서 보유 토큰 조회 API를 구현했습니다.
- 청약 마감 일자에 맞춰 자동으로 마감될 수 있도록 스케줄링 로직을 추가했습니다.
## 작업사항
- Subscription 테이블에 청약 데이터 추가
- Subscription 테이블의 스키마를 수정하여 청약 관련 데이터를 저장할 수 있도록 업데이트.
- 마이페이지 보유 토큰 조회 API 구현
- 사용자별 보유 중인 토큰 데이터를 반환하는 API를 개발.
- 청약 완료된 토큰은 별도 로직으로 반환 처리.
- 청약 마감 스케줄링 구현

## 변경로직
- DB 변경
Subscription 테이블에 새로운 컬럼 추가 (청약 관련 필드).
- API 추가
/subscribe/token 경로에 보유 토큰 조회 로직 추가.
마이페이지 API에 청약 완료 데이터를 반환하는 로직 추가.
- 스케줄링 추가
청약 마감 시간에 따라 데이터를 자동 업데이트하는 로직을 백그라운드 스케줄러로 구현.